### PR TITLE
Create equivalent_modules.json

### DIFF
--- a/equivalent_modules.json
+++ b/equivalent_modules.json
@@ -1,9 +1,11 @@
 {
     "argparse": "https://docs.python.org/3/library/argparse.html",
+    "BeautifulSoup": "https://pypi.python.org/pypi/beautifulsoup4",
     "futures": "http://docs.python.org/3/library/concurrent.futures.html",
     "ipaddr": "https://docs.python.org/3/library/ipaddress.html",
     "multiprocessing": "https://docs.python.org/3/library/multiprocessing.html",
     "MySQL-python": "https://pypi.python.org/pypi/mysqlclient",
+    "ordereddict": "https://docs.python.org/3/library/collections.html#collections.OrderedDict",
     "python-openid": "https://github.com/necaris/python3-openid",
     "simplejson": "https://docs.python.org/3/library/json.html",
     "suds": "https://pypi.python.org/pypi/suds-jurko",

--- a/equivalent_modules.json
+++ b/equivalent_modules.json
@@ -9,6 +9,7 @@
     "multiprocessing": "https://docs.python.org/3/library/multiprocessing.html",
     "MySQL-python": "https://pypi.python.org/pypi/mysqlclient",
     "ordereddict": "https://docs.python.org/3/library/collections.html#collections.OrderedDict",
+    "python-ldap": "https://pypi.python.org/pypi/pyldap"
     "python-openid": "https://github.com/necaris/python3-openid",
     "simplejson": "https://docs.python.org/3/library/json.html",
     "ssl": "https://docs.python.org/3/library/ssl.html",

--- a/equivalent_modules.json
+++ b/equivalent_modules.json
@@ -2,7 +2,7 @@
     "argparse": "https://docs.python.org/3/library/argparse.html",
     "BeautifulSoup": "https://pypi.python.org/pypi/beautifulsoup4",
     "fabric": "https://github.com/mathiasertl/fabric",
-    "functools32": "http://docs.python.org/3/library/functools.html",
+    "functools32": "https://docs.python.org/3/library/functools.html",
     "futures": "http://docs.python.org/3/library/concurrent.futures.html",
     "ipaddr": "https://docs.python.org/3/library/ipaddress.html",
     "ipaddress": "https://docs.python.org/3/library/ipaddress.html",
@@ -11,6 +11,7 @@
     "ordereddict": "https://docs.python.org/3/library/collections.html#collections.OrderedDict",
     "python-openid": "https://github.com/necaris/python3-openid",
     "simplejson": "https://docs.python.org/3/library/json.html",
+    "ssl": "https://docs.python.org/3/library/ssl.html",
     "suds": "https://pypi.python.org/pypi/suds-jurko",
     "unittest2": "https://docs.python.org/3/library/unittest.html",
     "uuid": "https://docs.python.org/3/library/uuid.html"

--- a/equivalent_modules.json
+++ b/equivalent_modules.json
@@ -1,8 +1,11 @@
 {
     "argparse": "https://docs.python.org/3/library/argparse.html",
     "BeautifulSoup": "https://pypi.python.org/pypi/beautifulsoup4",
+    "fabric": "https://github.com/mathiasertl/fabric",
+    "functools32": "http://docs.python.org/3/library/functools.html",
     "futures": "http://docs.python.org/3/library/concurrent.futures.html",
     "ipaddr": "https://docs.python.org/3/library/ipaddress.html",
+    "ipaddress": "https://docs.python.org/3/library/ipaddress.html",
     "multiprocessing": "https://docs.python.org/3/library/multiprocessing.html",
     "MySQL-python": "https://pypi.python.org/pypi/mysqlclient",
     "ordereddict": "https://docs.python.org/3/library/collections.html#collections.OrderedDict",

--- a/equivalent_modules.json
+++ b/equivalent_modules.json
@@ -1,0 +1,12 @@
+{
+    "argparse": "https://docs.python.org/3/library/argparse.html",
+    "futures": "http://docs.python.org/3/library/concurrent.futures.html",
+    "ipaddr": "https://docs.python.org/3/library/ipaddress.html",
+    "multiprocessing": "https://docs.python.org/3/library/multiprocessing.html",
+    "MySQL-python": "https://pypi.python.org/pypi/mysqlclient",
+    "python-openid": "https://github.com/necaris/python3-openid",
+    "simplejson": "https://docs.python.org/3/library/json.html",
+    "suds": "https://pypi.python.org/pypi/suds-jurko",
+    "unittest2": "https://docs.python.org/3/library/unittest.html",
+    "uuid": "https://docs.python.org/3/library/uuid.html"
+}


### PR DESCRIPTION
Move the module substitution dictionary out of the code to make updates easier.

Alternatively, this could be done with YAML instead of JSON.