### PR TITLE
Clear memcache just before the weekly update

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -8,7 +8,7 @@ cron:
   schedule: every 60 minutes
 
 - description: clear memcache before weekly update
-  url: /tasks/clear_cache
+  url: /tasks/clear_packages_cache
   schedule: every sunday 08:55
 
 - description: weekly update list of packages

--- a/cron.yaml
+++ b/cron.yaml
@@ -7,6 +7,10 @@ cron:
   url: /tasks/update_top
   schedule: every 60 minutes
 
+- description: clear memcache before weekly update
+  url: /tasks/clear_cache
+  schedule: every sunday 08:55
+
 - description: weekly update list of packages
   url: /tasks/package_list
   schedule: every sunday 09:00


### PR DESCRIPTION
This pull request must only be merged __AFTER__ pull requests https://github.com/ubershmekel/python3wos/pull/39 and https://github.com/ubershmekel/python3wos/pull/40 are already merged.

This should force the refresh of the package_list in https://github.com/ubershmekel/python3wos/blob/master/pypi_cron.py#L80

I sense that removing the stale cache might help to clear up issue https://github.com/ubershmekel/python3wos/issues/35