### PR TITLE
Created ClearPackagesCache()

### DIFF
--- a/pypi_cron.py
+++ b/pypi_cron.py
@@ -71,10 +71,7 @@ def set_mcache_package_list(package_names):
 
 def update_list_of_packages():
     package_names = get_mcache_package_list()
-    package_index = memcache.get(PACKAGES_CHECKED_INDEX)
-
-    if package_index is None:
-        package_index = 0
+    package_index = memcache.get(PACKAGES_CHECKED_INDEX) or 0
     
     if package_names is None:
         package_names = pypi_parser.get_list_of_packages()

--- a/pypi_cron.py
+++ b/pypi_cron.py
@@ -207,6 +207,15 @@ class ClearCache(webapp.RequestHandler):
         self.response.out.write("result: %s" % result)
 
 
+class ClearPackagesCache(webapp.RequestHandler):
+    def get(self):
+        from google.appengine.api import memcache
+        self.response.out.write("clearing package cache")
+        results = [memcache.delete(PACKAGES_CACHE_KEY),
+                   memcache.delete(PACKAGES_CHECKED_INDEX)]
+        self.response.out.write("results: %s" % results)
+
+
 # Request handler for the URL /update_datastore
 class update_models(webapp.RequestHandler):
     def get(self):


### PR DESCRIPTION
Running this should force PackageList() to refresh of the package_list in https://github.com/ubershmekel/python3wos/blob/master/pypi_cron.py#L80

I sense that removing the stale packages cache might help to clear up issue #35 where some PyPI Top 200 packages are not present in WoS.